### PR TITLE
More KInner <-> Pattern conversions

### DIFF
--- a/src/integration_tests/test_kore_to_kast.py
+++ b/src/integration_tests/test_kore_to_kast.py
@@ -4,6 +4,7 @@ from pyk.ktool import KompileBackend
 from pyk.ktool.kprint import SymbolTable
 from pyk.prelude.kbool import TRUE
 from pyk.prelude.kint import intToken
+from pyk.prelude.string import stringToken
 
 from .kprove_test import KProveTest
 
@@ -20,10 +21,16 @@ class KoreToKastTest(KProveTest):
     def test_bidirectional(self) -> None:
         kore_kast_pairs = (
             (
-                'domain-value',
+                'domain-value-int',
                 KSort('Int'),
                 DV(SortApp('SortInt'), String('3')),
                 intToken(3),
+            ),
+            (
+                'domain-value-string',
+                KSort('String'),
+                DV(SortApp('SortString'), String('foobar')),
+                stringToken('foobar'),
             ),
             (
                 'variable-with-sort',

--- a/src/integration_tests/test_kore_to_kast.py
+++ b/src/integration_tests/test_kore_to_kast.py
@@ -1,5 +1,5 @@
 from pyk.kast.inner import KApply, KLabel, KSequence, KSort, KVariable
-from pyk.kore.syntax import DV, And, App, Ceil, Equals, EVar, SortApp, String
+from pyk.kore.syntax import DV, And, App, Ceil, Equals, EVar, Not, SortApp, String
 from pyk.ktool import KompileBackend
 from pyk.ktool.kprint import SymbolTable
 from pyk.prelude.kbool import TRUE
@@ -92,6 +92,18 @@ class KoreToKastTest(KProveTest):
                 ),
                 KApply(
                     KLabel('#Ceil', [KSort('Bool'), KSort('GeneratedTopCell')]),
+                    [KVariable('X', sort=KSort('Bool'))],
+                ),
+            ),
+            (
+                'ml-not',
+                KSort('Bool'),
+                Not(
+                    SortApp('SortBool'),
+                    EVar('VarX', SortApp('SortBool')),
+                ),
+                KApply(
+                    KLabel('#Not', [KSort('Bool')]),
                     [KVariable('X', sort=KSort('Bool'))],
                 ),
             ),

--- a/src/pyk/ktool/kprint.py
+++ b/src/pyk/ktool/kprint.py
@@ -274,7 +274,10 @@ class KPrint:
         _LOGGER.debug(f'_kore_to_kast: {kore}')
 
         if type(kore) is DV and kore.sort.name.startswith('Sort'):
-            return KToken(kore.value.value, KSort(kore.sort.name[4:]))
+            token = kore.value.value
+            if kore.sort == SortApp('SortString'):
+                token = '"' + token + '"'
+            return KToken(token, KSort(kore.sort.name[4:]))
 
         elif type(kore) is EVar:
             vname = _unmunge(kore.name[3:])
@@ -362,7 +365,12 @@ class KPrint:
             return None
 
         if type(kast) is KToken:
-            dv: Pattern = DV(SortApp('Sort' + kast.sort.name), String(kast.token))
+            value = kast.token
+            if kast.sort == KSort('String'):
+                assert value.startswith('"')
+                assert value.endswith('"')
+                value = value[1:-1]
+            dv: Pattern = DV(SortApp('Sort' + kast.sort.name), String(value))
             if sort is not None:
                 dv = self._add_sort_injection(dv, kast.sort, sort)
             return dv

--- a/src/pyk/ktool/kprint.py
+++ b/src/pyk/ktool/kprint.py
@@ -148,7 +148,7 @@ def _kast(
     sort: Optional[str] = None,
     # ---
     check: bool = True,
-    profile: bool = True,
+    profile: bool = False,
 ) -> CompletedProcess:
     if input_file:
         check_file_path(input_file)

--- a/src/pyk/ktool/kprint.py
+++ b/src/pyk/ktool/kprint.py
@@ -30,7 +30,7 @@ from ..kast.outer import (
     read_kast_definition,
 )
 from ..kore.parser import KoreParser
-from ..kore.syntax import DV, And, App, Ceil, Equals, EVar, Pattern, SortApp, String
+from ..kore.syntax import DV, And, App, Ceil, Equals, EVar, Not, Pattern, SortApp, String
 from ..prelude.k import DOTS, EMPTY_K
 from ..prelude.kbool import TRUE
 
@@ -312,6 +312,12 @@ class KPrint:
             if larg is not None and rarg is not None:
                 return KApply(KLabel('#And', [psort]), [larg, rarg])
 
+        elif type(kore) is Not:
+            psort = KSort(kore.sort.name[4:])
+            arg = self._kore_to_kast(kore.pattern)
+            if arg is not None:
+                return KApply(KLabel('#Not', [psort]), [arg])
+
         elif type(kore) is Equals:
             osort = KSort(kore.op_sort.name[4:])
             psort = KSort(kore.sort.name[4:])
@@ -402,6 +408,13 @@ class KPrint:
                         if sort is not None:
                             _and = self._add_sort_injection(_and, psort, sort)
                         return _and
+                elif kast.label.name == '#Not' and kast.arity == 1:
+                    arg = self._kast_to_kore(kast.args[0], sort=psort)
+                    if arg is not None:
+                        _not: Pattern = Not(SortApp('Sort' + psort.name), arg)
+                        if sort is not None:
+                            _not = self._add_sort_injection(_not, psort, sort)
+                        return _not
 
             elif len(kast.label.params) == 2:
                 osort = kast.label.params[0]

--- a/src/pyk/ktool/krun.py
+++ b/src/pyk/ktool/krun.py
@@ -31,9 +31,12 @@ class KRun(KPrint):
         self,
         pgm: KInner,
         *,
+        config: Optional[Mapping[str, KInner]] = None,
         depth: Optional[int] = None,
         expand_macros: bool = False,
     ) -> CTerm:
+        pmap = {k: 'cat' for k in config} if config is not None else None
+        cmap = {k: self.kast_to_kore(v).text for k, v in config.items()} if config is not None else None
         with NamedTemporaryFile('w', dir=self.use_directory, delete=False) as ntf:
             ntf.write(self.pretty_print(pgm))
             ntf.flush()
@@ -45,6 +48,8 @@ class KRun(KPrint):
                 depth=depth,
                 no_expand_macros=not expand_macros,
                 profile=self._profile,
+                cmap=cmap,
+                pmap=pmap,
             )
 
         if result.returncode != 0:
@@ -125,7 +130,7 @@ class KRun(KPrint):
             definition_dir=self.definition_dir,
             output=KRunOutput.KORE,
             pmap={var: 'cat' for var in config},
-            cmap={var: pattern.text for var, pattern in config.items()},
+            cmap={var: pattern.text.replace(' ', '') for var, pattern in config.items()},
             depth=depth,
             no_expand_macros=not expand_macros,
             profile=self._profile,

--- a/src/pyk/ktool/krun.py
+++ b/src/pyk/ktool/krun.py
@@ -170,7 +170,7 @@ def _krun(
     no_expand_macros: bool = False,
     # ---
     check: bool = True,
-    profile: bool = True,
+    profile: bool = False,
 ) -> CompletedProcess:
     if input_file:
         check_file_path(input_file)


### PR DESCRIPTION
This adds conversions between KAst and Kore formats for the following:

- `#Not` symbol (test added).
- `KToken(..., KSort('String'))`, which was previously being encoded incorrectly (failing test added).

Also makes some other misc cleanups:

- 