### PR TITLE
Add missing imports for `pyk.kllvm.load`

### DIFF
--- a/src/tests/integration/kllvm/test_patterns.py
+++ b/src/tests/integration/kllvm/test_patterns.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import pyk.kllvm.load  # noqa: F401
 from pyk.kllvm.ast import CompositePattern, CompositeSort, Pattern, StringPattern, VariablePattern
 
 if TYPE_CHECKING:

--- a/src/tests/integration/kllvm/test_sorts.py
+++ b/src/tests/integration/kllvm/test_sorts.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import pyk.kllvm.load  # noqa: F401
 from pyk.kllvm.ast import CompositeSort, SortVariable
 
 if TYPE_CHECKING:

--- a/src/tests/integration/kllvm/test_step.py
+++ b/src/tests/integration/kllvm/test_step.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyk.kllvm.load  # noqa: F401
 from pyk.kllvm.parser import Parser
 
 from .utils import RuntimeTest

--- a/src/tests/integration/kllvm/test_symbols.py
+++ b/src/tests/integration/kllvm/test_symbols.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import pyk.kllvm.load  # noqa: F401
 from pyk.kllvm.ast import CompositeSort, Symbol, Variable
 
 if TYPE_CHECKING:


### PR DESCRIPTION
The bug didn't manifest as test discovery imports all the test modules, and one of them already imported the module.