### PR TITLE
Factor-out read_proof

### DIFF
--- a/src/pyk/proof/equality.py
+++ b/src/pyk/proof/equality.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -10,7 +9,6 @@ from ..kast.manip import extract_lhs, extract_rhs, flatten_label
 from ..prelude.k import GENERATED_TOP_CELL
 from ..prelude.kbool import BOOL, TRUE
 from ..prelude.ml import is_bottom, is_top, mlAnd, mlEquals
-from ..utils import hash_str
 from .proof import Proof, ProofStatus
 
 if TYPE_CHECKING:
@@ -84,15 +82,6 @@ class EqualityProof(Proof):
 
     def set_simplified_equality(self, simplified: KInner) -> None:
         self.simplified_equality = simplified
-
-    @staticmethod
-    def read_proof(id: str, proof_dir: Path) -> EqualityProof:
-        proof_path = proof_dir / f'{hash_str(id)}.json'
-        if EqualityProof.proof_exists(id, proof_dir):
-            proof_dict = json.loads(proof_path.read_text())
-            _LOGGER.info(f'Reading EqualityProof from file {id}: {proof_path}')
-            return EqualityProof.from_dict(proof_dict, proof_dir=proof_dir)
-        raise ValueError(f'Could not load EqualityProof from file {id}: {proof_path}')
 
     @property
     def status(self) -> ProofStatus:

--- a/src/pyk/proof/reachability.py
+++ b/src/pyk/proof/reachability.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING
 
 from pyk.kore.rpc import LogEntry
 
 from ..kcfg import KCFG
-from ..utils import hash_str, shorten_hashes
+from ..utils import shorten_hashes
 from .proof import Proof, ProofStatus
 
 if TYPE_CHECKING:
@@ -39,15 +38,6 @@ class APRProof(Proof):
         super().__init__(id, proof_dir=proof_dir)
         self.kcfg = kcfg
         self.logs = logs
-
-    @staticmethod
-    def read_proof(id: str, proof_dir: Path) -> APRProof:
-        proof_path = proof_dir / f'{hash_str(id)}.json'
-        if APRProof.proof_exists(id, proof_dir):
-            proof_dict = json.loads(proof_path.read_text())
-            _LOGGER.info(f'Reading APRProof from file {id}: {proof_path}')
-            return APRProof.from_dict(proof_dict, proof_dir=proof_dir)
-        raise ValueError(f'Could not load APRProof from file {id}: {proof_path}')
 
     @property
     def status(self) -> ProofStatus:
@@ -103,15 +93,6 @@ class APRBMCProof(APRProof):
         super().__init__(id, kcfg, logs, proof_dir=proof_dir)
         self.bmc_depth = bmc_depth
         self._bounded_states = list(bounded_states) if bounded_states is not None else []
-
-    @staticmethod
-    def read_proof(id: str, proof_dir: Path) -> APRBMCProof:
-        proof_path = proof_dir / f'{hash_str(id)}.json'
-        if APRBMCProof.proof_exists(id, proof_dir):
-            proof_dict = json.loads(proof_path.read_text())
-            _LOGGER.info(f'Reading APRBMCProof from file {id}: {proof_path}')
-            return APRBMCProof.from_dict(proof_dict, proof_dir=proof_dir)
-        raise ValueError(f'Could not load APRBMCProof from file {id}: {proof_path}')
 
     @property
     def status(self) -> ProofStatus:

--- a/src/pyk/proof/utils.py
+++ b/src/pyk/proof/utils.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Final
+
+from ..utils import hash_str
+from .equality import EqualityProof
+from .proof import Proof
+from .reachability import APRBMCProof, APRProof
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+def read_proof(id: str, proof_dir: Path) -> APRProof | APRBMCProof | EqualityProof:
+    proof_path = proof_dir / f'{hash_str(id)}.json'
+    if Proof.proof_exists(id, proof_dir):
+        proof_dict = json.loads(proof_path.read_text())
+        proof_type = proof_dict['type']
+        _LOGGER.info(f'Reading {proof_type} from file {id}: {proof_path}')
+        match proof_type:
+            case 'APRProof':
+                return APRProof.from_dict(proof_dict, proof_dir=proof_dir)
+            case 'APRBMCProof':
+                return APRBMCProof.from_dict(proof_dict, proof_dir=proof_dir)
+            case 'EqualityProof':
+                return EqualityProof.from_dict(proof_dict, proof_dir=proof_dir)
+
+    raise ValueError(f'Could not load APRBMCProof from file {id}: {proof_path}')

--- a/src/tests/unit/test_proof.py
+++ b/src/tests/unit/test_proof.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from pyk.kcfg.kcfg import KCFG
+from pyk.prelude.kbool import BOOL
+from pyk.prelude.kint import intToken
+from pyk.proof.equality import EqualityProof
+from pyk.proof.reachability import APRBMCProof, APRProof
+from pyk.proof.utils import read_proof
+
+from .test_kcfg import node_dicts
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import TempPathFactory
+
+
+@pytest.fixture(scope='class')
+def proof_dir(tmp_path_factory: TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp('proofs')
+
+
+PROOF_TEST_DATA: list[dict[str, Any]] = [
+    {
+        'proof_type': 'APRProof',
+        'proof_param': 1,
+    },
+    {
+        'proof_type': 'APRBMCProof',
+        'proof_param': 1,
+    },
+    {
+        'proof_type': 'EqualityProof',
+        'proof_param': 1,
+    },
+]
+
+
+@pytest.fixture(scope='class', params=PROOF_TEST_DATA)
+def sample_proof(
+    request: pytest.FixtureRequest,
+    proof_dir: Path,
+) -> APRProof | APRBMCProof | EqualityProof:
+    proof_type = request.param['proof_type']
+    proof_param = request.param['proof_param']
+    match proof_type:
+        case 'APRProof':
+            return APRProof(
+                id=f'apr_proof_{proof_param}',
+                kcfg=KCFG.from_dict({'nodes': node_dicts(proof_param)}),
+                logs={},
+                proof_dir=proof_dir,
+            )
+        case 'APRBMCProof':
+            return APRBMCProof(
+                id=f'aprbmc_proof_{proof_param}',
+                bmc_depth=proof_param,
+                kcfg=KCFG.from_dict({'nodes': node_dicts(proof_param)}),
+                logs={},
+                proof_dir=proof_dir,
+            )
+        case _:  # EqualityProof
+            return EqualityProof(
+                id=f'equality_proof_{proof_param}',
+                lhs_body=intToken(proof_param),
+                rhs_body=intToken(proof_param),
+                sort=BOOL,
+                proof_dir=proof_dir,
+            )
+
+
+class TestProof:
+    def test_read_proof(self, sample_proof: APRProof | APRBMCProof | EqualityProof) -> None:
+        # Given
+        assert sample_proof.proof_dir
+        sample_proof.write_proof()
+
+        # When
+        proof_from_disk = read_proof(id=sample_proof.id, proof_dir=sample_proof.proof_dir)
+
+        # Then
+        assert proof_from_disk.dict == sample_proof.dict


### PR DESCRIPTION
Part of [evm-semantics#1775](https://github.com/runtimeverification/evm-semantics/issues/1775) and #394

This PR introduces a generic `read_proof` function that creates an object of the appropriate type (i.e. `APRProof`, `APRBMCProof` or `EqualityProof`) depending on the `'type'` JSON field of the serialized proof.