### PR TITLE
Evaluate pending nodes in parallel

### DIFF
--- a/src/pyk/kcfg/explore.py
+++ b/src/pyk/kcfg/explore.py
@@ -55,7 +55,7 @@ class KCFGExplore(ContextManager['KCFGExplore']):
     _bug_report: BugReport | None
 
     _kore_server: KoreServer | None
-    _kore_clients: list[KoreClient]
+    _kore_clients: list[KoreClient] = []
     _rpc_closed: bool
     _trace_rewrites: bool
 

--- a/src/pyk/kcfg/explore.py
+++ b/src/pyk/kcfg/explore.py
@@ -55,7 +55,7 @@ class KCFGExplore(ContextManager['KCFGExplore']):
     _bug_report: BugReport | None
 
     _kore_server: KoreServer | None
-    _kore_client: KoreClient | None
+    _kore_clients: list[KoreClient]
     _rpc_closed: bool
     _trace_rewrites: bool
 
@@ -112,18 +112,18 @@ class KCFGExplore(ContextManager['KCFGExplore']):
                 haskell_log_entries=self._haskell_log_entries,
                 log_axioms_file=self._log_axioms_file,
             )
-        if not self._kore_client:
-            self._kore_client = KoreClient('localhost', self._kore_server._port, bug_report=self._bug_report)
-        return (self._kore_server, self._kore_client)
+        if not self._kore_clients or not any(not client._busy for client in self._kore_clients):
+            self._kore_clients.append(KoreClient('localhost', self._kore_server._port, bug_report=self._bug_report))
+        return (self._kore_server, next(client for client in self._kore_clients if not client._busy))
 
     def close(self) -> None:
         self._rpc_closed = True
         if self._kore_server is not None:
             self._kore_server.close()
             self._kore_server = None
-        if self._kore_client is not None:
-            self._kore_client.close()
-            self._kore_client = None
+        while self._kore_clients:
+            client = self._kore_clients.pop()
+            client.close()
 
     def cterm_execute(
         self,

--- a/src/pyk/proof/reachability.py
+++ b/src/pyk/proof/reachability.py
@@ -4,8 +4,8 @@ import json
 import logging
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING
 from multiprocessing.pool import ThreadPool as Pool
+from typing import TYPE_CHECKING
 
 from pyk.kore.rpc import LogEntry
 
@@ -512,7 +512,6 @@ class APRProver(Prover):
                 terminal_rules=terminal_rules,
             )
 
-
         while self.proof.pending:
             self.proof.write_proof()
 
@@ -524,7 +523,6 @@ class APRProver(Prover):
             curr_nodes = [node.id for ni, node in enumerate(self.proof.pending) if ni < max_workers]
             pool = Pool(processes=max_workers)
             pool.map(_advance_from_node, curr_nodes)
-
 
         self.proof.write_proof()
         return self.proof.kcfg
@@ -687,6 +685,7 @@ class APRBMCProver(APRProver):
         cut_point_rules: Iterable[str] = (),
         terminal_rules: Iterable[str] = (),
         implication_every_block: bool = True,
+        max_workers: int = 1,
     ) -> KCFG:
         iterations = 0
 

--- a/src/pyk/proof/reachability.py
+++ b/src/pyk/proof/reachability.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 from itertools import chain
 from typing import TYPE_CHECKING
-from multiprocessing import Pool
+from multiprocessing.pool import ThreadPool as Pool
 
 from pyk.kore.rpc import LogEntry
 
@@ -482,6 +482,37 @@ class APRProver(Prover):
     ) -> KCFG:
         iterations = 0
 
+        def _advance_from_node(nid: NodeIdLike) -> None:
+            _LOGGER.info(f'advancing on node {nid}')
+            node = self.proof.kcfg.node(nid)
+            if self._check_subsume(node):
+                return
+
+            if self._check_terminal(node):
+                return
+
+            if self._check_abstract(node):
+                return
+
+            if self._extract_branches is not None and len(self.proof.kcfg.splits(target_id=nid)) == 0:
+                branches = list(self._extract_branches(node.cterm))
+                if len(branches) > 0:
+                    self.proof.kcfg.split_on_constraints(nid, branches)
+                    _LOGGER.info(
+                        f'Found {len(branches)} branches using heuristic for node {self.proof.id}: {shorten_hashes(nid)}: {[self.kcfg_explore.kprint.pretty_print(bc) for bc in branches]}'
+                    )
+                    return
+
+            self.kcfg_explore.extend(
+                self.proof.kcfg,
+                node,
+                self.proof.logs,
+                execute_depth=execute_depth,
+                cut_point_rules=cut_point_rules,
+                terminal_rules=terminal_rules,
+            )
+
+
         while self.proof.pending:
             self.proof.write_proof()
 
@@ -489,36 +520,6 @@ class APRProver(Prover):
                 _LOGGER.warning(f'Reached iteration bound {self.proof.id}: {max_iterations}')
                 break
             iterations += 1
-
-            def _advance_from_node(nid: NodeIdLike) -> None:
-                _LOGGER.debug(f'advancing on node {nid}')
-                node = self.proof.kcfg.node(nid)
-                if self._check_subsume(node):
-                    return
-
-                if self._check_terminal(node):
-                    return
-
-                if self._check_abstract(node):
-                    return
-
-                if self._extract_branches is not None and len(self.proof.kcfg.splits(target_id=nid)) == 0:
-                    branches = list(self._extract_branches(node.cterm))
-                    if len(branches) > 0:
-                        self.proof.kcfg.split_on_constraints(nid, branches)
-                        _LOGGER.info(
-                            f'Found {len(branches)} branches using heuristic for node {self.proof.id}: {shorten_hashes(nid)}: {[self.kcfg_explore.kprint.pretty_print(bc) for bc in branches]}'
-                        )
-                        return
-
-                self.kcfg_explore.extend(
-                    self.proof.kcfg,
-                    node,
-                    self.proof.logs,
-                    execute_depth=execute_depth,
-                    cut_point_rules=cut_point_rules,
-                    terminal_rules=terminal_rules,
-                )
 
             curr_nodes = [node.id for ni, node in enumerate(self.proof.pending) if ni < max_workers]
             pool = Pool(processes=max_workers)


### PR DESCRIPTION
When having a lot of branching, it may take a lot of time to evaluate proofs on pending nodes because this is done sequentially.
In this case, we can run them on the pending leaves by running the proofs in parallel at a small cost.
This feature adds a new parameter `max_workers` with a default of 1 for the old behavior in the `advance_proof` of the `Prover` and will cap the amount of proving processes running in parallel whenever there are these pending nodes.