### PR TITLE
Add profiling test for loading a large semantics

### DIFF
--- a/src/tests/profiling/profile_kast_json.py
+++ b/src/tests/profiling/profile_kast_json.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from pyk.kast import kast_term
 
 from .utils import TEST_DATA_DIR
@@ -12,10 +14,18 @@ if TYPE_CHECKING:
     from pyk.testing import Profiler
 
 
-def test_kast_json(profile: Profiler) -> None:
-    json_file = TEST_DATA_DIR / 'kast.json'
-    with json_file.open() as f:
-        json_data = json.load(f)
+KAST_JSON_TEST_DATA: list[tuple[str, str]] = [
+    ('kast-term', 'kast.json'),
+    ('compiled-defn', 'compiled.json'),
+]
+
+
+@pytest.mark.parametrize('test_id,file_name', KAST_JSON_TEST_DATA, ids=[test_id for test_id, *_ in KAST_JSON_TEST_DATA])
+def test_kast_json(profile: Profiler, test_id: str, file_name: str) -> None:
+    json_file = TEST_DATA_DIR / file_name
+    with profile('json-load.prof', sort_keys=('cumtime',), limit=20):
+        with json_file.open() as f:
+            json_data = json.load(f)
 
     with profile('json-to-kast.prof', sort_keys=('cumtime',), limit=20):
         kast: KAst = kast_term(json_data)


### PR DESCRIPTION
This is a definition created from a Foundry test-suite which just has 2 contracts in it. This semantics is ~40MB, when loading the entire actual KEVM foundry test-suite, it's closer to ~120MB.

This enables profiling the loading of this large term, as per data collected here: https://github.com/runtimeverification/pyk/issues/548