### PR TITLE
Hotfix for the handling of bottom and top for the `CTerm` class

### DIFF
--- a/src/pyk/__main__.py
+++ b/src/pyk/__main__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from argparse import ArgumentParser, FileType
@@ -100,7 +99,7 @@ def exec_prove(args: Namespace) -> None:
     kompiled_dir: Path = args.definition_dir
     kprover = KProve(kompiled_dir, args.main_file)
     final_state = kprover.prove(Path(args.spec_file), spec_module_name=args.spec_module, args=args.kArgs)
-    args.output_file.write(json.dumps(mlOr([state.kast for state in final_state]).to_dict()))
+    args.output_file.write(final_state.to_json())
     _LOGGER.info(f'Wrote file: {args.output_file.name}')
 
 

--- a/src/pyk/__main__.py
+++ b/src/pyk/__main__.py
@@ -99,7 +99,7 @@ def exec_prove(args: Namespace) -> None:
     kompiled_dir: Path = args.definition_dir
     kprover = KProve(kompiled_dir, args.main_file)
     final_state = kprover.prove(Path(args.spec_file), spec_module_name=args.spec_module, args=args.kArgs)
-    args.output_file.write(final_state.to_json())
+    args.output_file.write(final_state.kast.to_json())
     _LOGGER.info(f'Wrote file: {args.output_file.name}')
 
 

--- a/src/pyk/cterm.py
+++ b/src/pyk/cterm.py
@@ -98,6 +98,14 @@ class CTerm:
             return True
         return False
 
+    @cached_property
+    def is_top(self) -> bool:
+        return CTerm._is_top(self.kast)
+
+    @cached_property
+    def is_bottom(self) -> bool:
+        return CTerm._is_bottom(self.kast)
+
     @staticmethod
     def _is_top(kast: KInner) -> bool:
         flat = flatten_label('#And', kast)

--- a/src/pyk/ktool/kprove.py
+++ b/src/pyk/ktool/kprove.py
@@ -12,7 +12,7 @@ from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from ..cli.utils import check_dir_path, check_file_path
-from ..cterm import build_claim, CTerm
+from ..cterm import CTerm, build_claim
 from ..kast import kast_term
 from ..kast.inner import KInner
 from ..kast.manip import extract_subst, flatten_label, free_vars
@@ -305,9 +305,11 @@ class KProve(KPrint):
             allow_zero_step=allow_zero_step,
             depth=depth,
         )
-        next_states = list(unique(var_map(ns) for ns in flatten_label('#Or', next_state) if not is_top(ns)))
+        next_states = list(unique(var_map(ns) for ns in flatten_label('#Or', next_state.kast) if not is_top(ns)))
         constraint_subst, _ = extract_subst(init_cterm.kast)
-        next_states_cterm = [CTerm.from_kast(mlAnd([constraint_subst.unapply(ns), constraint_subst.ml_pred])) for ns in next_states]
+        next_states_cterm = [
+            CTerm.from_kast(mlAnd([constraint_subst.unapply(ns), constraint_subst.ml_pred])) for ns in next_states
+        ]
         return next_states_cterm if len(next_states_cterm) > 0 else [CTerm.top()]
 
     def get_claim_modules(

--- a/src/pyk/ktool/kprove.py
+++ b/src/pyk/ktool/kprove.py
@@ -249,7 +249,7 @@ class KProve(KPrint):
 
         debug_log = _get_rule_log(log_file)
         final_state = CTerm.from_kast(kast_term(json.loads(proc_result.stdout), KInner))  # type: ignore # https://github.com/python/mypy/issues/4717
-        if final_state.is_top() and len(debug_log) == 0 and not allow_zero_step:
+        if final_state.is_top and len(debug_log) == 0 and not allow_zero_step:
             raise ValueError(f'Proof took zero steps, likely the LHS is invalid: {spec_file}')
         return final_state
 

--- a/src/pyk/proof/reachability.py
+++ b/src/pyk/proof/reachability.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from pyk.kore.rpc import LogEntry
 
-from ..kast.inner import KInner, KRewrite, KSort, Subst
+from ..kast.inner import KRewrite, KSort
 from ..kast.manip import flatten_label, ml_pred_to_bool
 from ..kast.outer import KClaim
 from ..kcfg import KCFG
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from ..kcfg import KCFGExplore
     from ..kcfg.kcfg import NodeIdLike
     from ..ktool.kprint import KPrint
+    from ..kast.inner import KInner
 
     T = TypeVar('T', bound='Proof')
 
@@ -789,21 +790,22 @@ class APRFailureInfo:
         failure_reasons = {}
         models = {}
         for node in proof.failing:
-            node_cterm, _ = kcfg_explore.cterm_simplify(node.cterm)
-            target_cterm, _ = kcfg_explore.cterm_simplify(target.cterm)
-            _, reason = kcfg_explore.implication_failure_reason(node_cterm, target_cterm)
-            path_condition = kcfg_explore.kprint.pretty_print(proof.path_constraints(node.id))
-            failure_reasons[node.id] = reason
-            path_conditions[node.id] = path_condition
-            if counterexample_info:
-                model_subst = kcfg_explore.cterm_get_model(node.cterm)
-                if type(model_subst) is Subst:
-                    model: list[tuple[str, str]] = []
-                    for var, term in model_subst.to_dict().items():
-                        term_kast = KInner.from_dict(term)
-                        term_pretty = kcfg_explore.kprint.pretty_print(term_kast)
-                        model.append((var, term_pretty))
-                    models[node.id] = model
+            pass
+            # node_cterm, _ = kcfg_explore.cterm_simplify(node.cterm)
+            # target_cterm, _ = kcfg_explore.cterm_simplify(target.cterm)
+            # _, reason = kcfg_explore.implication_failure_reason(node_cterm, target_cterm)
+            # path_condition = kcfg_explore.kprint.pretty_print(proof.path_constraints(node.id))
+            # failure_reasons[node.id] = reason
+            # path_conditions[node.id] = path_condition
+            # if counterexample_info:
+            #     model_subst = kcfg_explore.cterm_get_model(node.cterm)
+            #     if type(model_subst) is Subst:
+            #         model: list[tuple[str, str]] = []
+            #         for var, term in model_subst.to_dict().items():
+            #             term_kast = KInner.from_dict(term)
+            #             term_pretty = kcfg_explore.kprint.pretty_print(term_kast)
+            #             model.append((var, term_pretty))
+            #         models[node.id] = model
         return APRFailureInfo(
             failing_nodes=failing_nodes,
             pending_nodes=pending_nodes,

--- a/src/pyk/proof/reachability.py
+++ b/src/pyk/proof/reachability.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from pyk.kore.rpc import LogEntry
 
-from ..kast.inner import KRewrite, KSort
+from ..kast.inner import KInner, KRewrite, KSort, Subst
 from ..kast.manip import flatten_label, ml_pred_to_bool
 from ..kast.outer import KClaim
 from ..kcfg import KCFG
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from ..kcfg import KCFGExplore
     from ..kcfg.kcfg import NodeIdLike
     from ..ktool.kprint import KPrint
-    from ..kast.inner import KInner
 
     T = TypeVar('T', bound='Proof')
 
@@ -790,22 +789,21 @@ class APRFailureInfo:
         failure_reasons = {}
         models = {}
         for node in proof.failing:
-            pass
-            # node_cterm, _ = kcfg_explore.cterm_simplify(node.cterm)
-            # target_cterm, _ = kcfg_explore.cterm_simplify(target.cterm)
-            # _, reason = kcfg_explore.implication_failure_reason(node_cterm, target_cterm)
-            # path_condition = kcfg_explore.kprint.pretty_print(proof.path_constraints(node.id))
-            # failure_reasons[node.id] = reason
-            # path_conditions[node.id] = path_condition
-            # if counterexample_info:
-            #     model_subst = kcfg_explore.cterm_get_model(node.cterm)
-            #     if type(model_subst) is Subst:
-            #         model: list[tuple[str, str]] = []
-            #         for var, term in model_subst.to_dict().items():
-            #             term_kast = KInner.from_dict(term)
-            #             term_pretty = kcfg_explore.kprint.pretty_print(term_kast)
-            #             model.append((var, term_pretty))
-            #         models[node.id] = model
+            node_cterm, _ = kcfg_explore.cterm_simplify(node.cterm)
+            target_cterm, _ = kcfg_explore.cterm_simplify(target.cterm)
+            _, reason = kcfg_explore.implication_failure_reason(node_cterm, target_cterm)
+            path_condition = kcfg_explore.kprint.pretty_print(proof.path_constraints(node.id))
+            failure_reasons[node.id] = reason
+            path_conditions[node.id] = path_condition
+            if counterexample_info:
+                model_subst = kcfg_explore.cterm_get_model(node.cterm)
+                if type(model_subst) is Subst:
+                    model: list[tuple[str, str]] = []
+                    for var, term in model_subst.to_dict().items():
+                        term_kast = KInner.from_dict(term)
+                        term_pretty = kcfg_explore.kprint.pretty_print(term_kast)
+                        model.append((var, term_pretty))
+                    models[node.id] = model
         return APRFailureInfo(
             failing_nodes=failing_nodes,
             pending_nodes=pending_nodes,

--- a/src/tests/integration/kprove/test_emit_json_spec.py
+++ b/src/tests/integration/kprove/test_emit_json_spec.py
@@ -5,12 +5,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.cterm import CTerm
 from pyk.kast.kast import EMPTY_ATT
 from pyk.kast.manip import remove_generated_cells
 from pyk.kast.outer import KDefinition, KRequire
 from pyk.kast.pretty import paren
-from pyk.prelude.ml import mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -43,7 +41,7 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove_claim(spec_module.claims[0], 'looping-1')
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert result.is_top
 
     def test_prove(self, kprove: KProve, spec_module: KFlatModule) -> None:
         # Given
@@ -64,4 +62,4 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove(spec_file, spec_module_name=spec_module_name, args=['-I', str(include_dir)])
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert result.is_top

--- a/src/tests/integration/kprove/test_print_prove_rewrite.py
+++ b/src/tests/integration/kprove/test_print_prove_rewrite.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KRewrite, KVariable
 from pyk.kast.manip import push_down_rewrites
 from pyk.kast.outer import KClaim
-from pyk.prelude.ml import mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -47,4 +45,4 @@ class TestPrintProveRewrite(KProveTest):
 
         # Then
         assert actual == expected
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert result.is_top

--- a/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
+++ b/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast import KAtt
 from pyk.kast.inner import KToken
 from pyk.kast.outer import KClaim, KRule
 from pyk.prelude.kbool import BOOL
-from pyk.prelude.ml import mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -36,5 +34,5 @@ class TestSimpleProof(KProveTest):
         result2 = kprove.prove_claim(claim, 'claim-with-lemma', lemmas=[lemma])
 
         # Then
-        assert not CTerm._is_top(mlOr([res.kast for res in result1]))
-        assert CTerm._is_top(mlOr([res.kast for res in result2]))
+        assert not result1.is_top
+        assert result2.is_top

--- a/src/tests/integration/test_pyk.py
+++ b/src/tests/integration/test_pyk.py
@@ -93,5 +93,5 @@ class TestMinimizeTerm(KompiledTest):
         main()
         assume_argv(['pyk', 'print', str(definition_dir), str(prove_res_file), '--output-file', str(actual_file)])
         main()
-        # assert expected_file.read_text() == actual_file.read_text()
+        assert expected_file.read_text() == actual_file.read_text()
         expected_file.write_text(actual_file.read_text())


### PR DESCRIPTION
https://github.com/runtimeverification/pyk/pull/621 introduced a bug, it was falsely simplifying to `Bottom` because it was returning the disjunct of all states  when using the `prove_cterm` endpoint. This got uncovered as part of https://github.com/runtimeverification/evm-semantics/pull/2041