### PR TITLE
Re-enable LLVM backend Unicode tests

### DIFF
--- a/src/tests/integration/test_string.py
+++ b/src/tests/integration/test_string.py
@@ -184,13 +184,6 @@ def test_cli_rule_to_kast(llvm_dir: Path, text: str) -> None:
 
 @pytest.mark.parametrize('text', TEST_DATA, ids=TEST_DATA)
 def test_krun(backend: str, definition_dir: Path, text: str) -> None:
-    if backend == 'llvm':
-        try:
-            text.encode('latin-1')
-        except ValueError:
-            # https://github.com/runtimeverification/k/issues/3344
-            pytest.skip()
-
     # Given
     kore = kore_config(text, '')
     expected = kore_config(None, text)


### PR DESCRIPTION
The LLVM backend no longer conflates Bytes and Unicode strings, so we can re-enable the string integration tests