### PR TITLE
Fix KCFG.replace_node functionality

### DIFF
--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -545,6 +545,46 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         self._nodes[node_id] = node
         self._created_nodes.add(node.id)
 
+        for succ in self.successors(node_id):
+            if type(succ) is KCFG.Edge:
+                new_edge = KCFG.Edge(node, succ.target, succ.depth, succ.rules)
+                self._edges[succ.source.id][succ.target.id] = new_edge
+            if type(succ) is KCFG.Cover:
+                new_cover = KCFG.Cover(node, succ.target, succ.csubst)
+                self._covers[succ.source.id][succ.target.id] = new_cover
+            if type(succ) is KCFG.Split:
+                new_split = KCFG.Split(node, succ._targets)
+                self._splits[succ.source.id] = new_split
+            if type(succ) is KCFG.NDBranch:
+                new_ndbranch = KCFG.NDBranch(node, succ._targets, succ.rules)
+                self._ndbranches[succ.source.id] = new_ndbranch
+
+        for pred in self.predecessors(node_id):
+            if type(pred) is KCFG.Edge:
+                new_edge = KCFG.Edge(pred.source, node, pred.depth, pred.rules)
+                self._edges[pred.source.id][pred.target.id] = new_edge
+            if type(pred) is KCFG.Cover:
+                new_cover = KCFG.Cover(pred.source, node, pred.csubst)
+                self._covers[pred.source.id][pred.target.id] = new_cover
+            if type(pred) is KCFG.Split:
+                new_split_targets = []
+                for _target, csubst in pred._targets:
+                    if _target.id == node_id:
+                        new_split_targets.append((node, csubst))
+                    else:
+                        new_split_targets.append((_target, csubst))
+                new_split = KCFG.Split(pred.source, new_split_targets)
+                self._splits[pred.source.id] = new_split
+            if type(pred) is KCFG.NDBranch:
+                new_ndbranch_targets = []
+                for _target in pred._targets:
+                    if _target.id == node_id:
+                        new_ndbranch_targets.append(node)
+                    else:
+                        new_ndbranch_targets.append(_target)
+                new_ndbranch = KCFG.NDBranch(pred.source, new_ndbranch_targets, pred.rules)
+                self._ndbranches[pred.source.id] = new_ndbranch
+
     def successors(
         self,
         source_id: NodeIdLike,

--- a/src/tests/unit/test_kcfg.py
+++ b/src/tests/unit/test_kcfg.py
@@ -394,6 +394,29 @@ def test_vacuous() -> None:
     assert cfg.vacuous, node(3)
 
 
+def test_replace_node() -> None:
+    # Given
+    d = {
+        'nodes': node_dicts(4),
+        'edges': edge_dicts((1, 2), (2, 3)),
+    }
+
+    cfg = KCFG.from_dict(d)
+    cfg.replace_node(2, term(5))
+
+    node = cfg.node(2)
+    assert node is not None
+    assert node.cterm == term(5)
+
+    first_edge = cfg.edge(1, 2)
+    assert first_edge is not None
+    assert first_edge.target.cterm == term(5)
+
+    second_edge = cfg.edge(2, 3)
+    assert second_edge is not None
+    assert second_edge.source.cterm == term(5)
+
+
 def test_aliases() -> None:
     # Given
     d = {


### PR DESCRIPTION
Fixes: https://github.com/runtimeverification/pyk/issues/686

Currently, `KCFG.replace_node` is broken because `KCFG.Successor` stores directly a `KCFG.Node` for the sources and targets. So when we replace a node in the store currently, we are only replacing the node itself, but not iterating through the successors and replacing occurances of the same node there.

This PR uses a pretty brute-force way to do that (to be able to make progress on storing Node attributes on nodes directly instead of as separate lists), and later we can make a better way of storing this information: https://github.com/runtimeverification/pyk/issues/919.