### PR TITLE
Refactor KCFG loading capabalities

### DIFF
--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -468,26 +468,19 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         cfg = KCFG(optimize_memory=optimize_memory)
 
         for node_dict in dct.get('nodes') or []:
-            node_id = node_dict['id']
-            cterm = CTerm.from_dict(node_dict['cterm'])
-            node = KCFG.Node(node_id, cterm)
+            node = KCFG.Node.from_dict(node_dict)
             cfg.add_node(node)
 
         max_id = max([node.id for node in cfg.nodes], default=0)
         cfg._node_id = dct.get('next', max_id + 1)
 
         for edge_dict in dct.get('edges') or []:
-            source_id = edge_dict['source']
-            target_id = edge_dict['target']
-            depth = edge_dict['depth']
-            rules = edge_dict['rules']
-            cfg.create_edge(source_id, target_id, depth, rules=rules)
+            edge = KCFG.Edge.from_dict(edge_dict, cfg._nodes)
+            cfg.add_successor(edge)
 
         for cover_dict in dct.get('covers') or []:
-            source_id = cover_dict['source']
-            target_id = cover_dict['target']
-            csubst = CSubst.from_dict(cover_dict['csubst'])
-            cfg.create_cover(source_id, target_id, csubst=csubst)
+            cover = KCFG.Cover.from_dict(cover_dict, cfg._nodes)
+            cfg.add_successor(cover)
 
         for vacuous_id in dct.get('vacuous') or []:
             cfg.add_vacuous(vacuous_id)
@@ -499,17 +492,12 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             cfg.add_alias(alias=alias, node_id=node_id)
 
         for split_dict in dct.get('splits') or []:
-            source_id = split_dict['source']
-            targets = [
-                (target_dict['target'], CSubst.from_dict(target_dict['csubst']))
-                for target_dict in split_dict['targets']
-            ]
-            cfg.create_split(source_id, targets)
+            split = KCFG.Split.from_dict(split_dict, cfg._nodes)
+            cfg.add_successor(split)
 
         for ndbranch_dict in dct.get('ndbranches') or []:
-            source_id = ndbranch_dict['source']
-            target_ids = ndbranch_dict['targets']
-            cfg.create_ndbranch(source_id, target_ids)
+            ndbranch = KCFG.NDBranch.from_dict(ndbranch_dict, cfg._nodes)
+            cfg.add_successor(ndbranch)
 
         return cfg
 

--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -48,6 +48,10 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         def to_dict(self) -> dict[str, Any]:
             return {'id': self.id, 'cterm': self.cterm.to_dict()}
 
+        @staticmethod
+        def from_dict(dct: dict[str, Any]) -> KCFG.Node:
+            return KCFG.Node(dct['id'], CTerm.from_dict(dct['cterm']))
+
     class Successor(ABC):
         source: KCFG.Node
 

--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -482,6 +482,14 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             cover = KCFG.Cover.from_dict(cover_dict, cfg._nodes)
             cfg.add_successor(cover)
 
+        for split_dict in dct.get('splits') or []:
+            split = KCFG.Split.from_dict(split_dict, cfg._nodes)
+            cfg.add_successor(split)
+
+        for ndbranch_dict in dct.get('ndbranches') or []:
+            ndbranch = KCFG.NDBranch.from_dict(ndbranch_dict, cfg._nodes)
+            cfg.add_successor(ndbranch)
+
         for vacuous_id in dct.get('vacuous') or []:
             cfg.add_vacuous(vacuous_id)
 
@@ -490,14 +498,6 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
 
         for alias, node_id in dct.get('aliases', {}).items():
             cfg.add_alias(alias=alias, node_id=node_id)
-
-        for split_dict in dct.get('splits') or []:
-            split = KCFG.Split.from_dict(split_dict, cfg._nodes)
-            cfg.add_successor(split)
-
-        for ndbranch_dict in dct.get('ndbranches') or []:
-            ndbranch = KCFG.NDBranch.from_dict(ndbranch_dict, cfg._nodes)
-            cfg.add_successor(ndbranch)
 
         return cfg
 

--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -467,14 +467,13 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
     def from_dict(dct: Mapping[str, Any], optimize_memory: bool = True) -> KCFG:
         cfg = KCFG(optimize_memory=optimize_memory)
 
-        max_id = 0
         for node_dict in dct.get('nodes') or []:
             node_id = node_dict['id']
-            max_id = max(max_id, node_id)
             cterm = CTerm.from_dict(node_dict['cterm'])
             node = KCFG.Node(node_id, cterm)
             cfg.add_node(node)
 
+        max_id = max([node.id for node in cfg.nodes], default=0)
         cfg._node_id = dct.get('next', max_id + 1)
 
         for edge_dict in dct.get('edges') or []:

--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -83,7 +83,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
 
         @staticmethod
         @abstractmethod
-        def from_dict(dct: dict[str, Any], nodes: dict[int, KCFG.Node]) -> KCFG.Successor:
+        def from_dict(dct: dict[str, Any], nodes: MutableMapping[int, KCFG.Node]) -> KCFG.Successor:
             ...
 
     class EdgeLike(Successor):
@@ -111,7 +111,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             }
 
         @staticmethod
-        def from_dict(dct: dict[str, Any], nodes: dict[int, KCFG.Node]) -> KCFG.Edge:
+        def from_dict(dct: dict[str, Any], nodes: MutableMapping[int, KCFG.Node]) -> KCFG.Edge:
             return KCFG.Edge(nodes[dct['source']], nodes[dct['target']], dct['depth'], tuple(dct['rules']))
 
         def to_rule(self, label: str, claim: bool = False, priority: int | None = None) -> KRuleLike:
@@ -156,7 +156,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             }
 
         @staticmethod
-        def from_dict(dct: dict[str, Any], nodes: dict[int, KCFG.Node]) -> KCFG.Cover:
+        def from_dict(dct: dict[str, Any], nodes: MutableMapping[int, KCFG.Node]) -> KCFG.Cover:
             return KCFG.Cover(nodes[dct['source']], nodes[dct['target']], CSubst.from_dict(dct['csubst']))
 
         def replace_source(self, node: KCFG.Node) -> KCFG.Cover:
@@ -211,7 +211,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             }
 
         @staticmethod
-        def from_dict(dct: dict[str, Any], nodes: dict[int, KCFG.Node]) -> KCFG.Split:
+        def from_dict(dct: dict[str, Any], nodes: MutableMapping[int, KCFG.Node]) -> KCFG.Split:
             _targets = [(nodes[target['target']], CSubst.from_dict(target['csubst'])) for target in dct['targets']]
             return KCFG.Split(nodes[dct['source']], tuple(_targets))
 
@@ -258,7 +258,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             }
 
         @staticmethod
-        def from_dict(dct: dict[str, Any], nodes: dict[int, KCFG.Node]) -> KCFG.NDBranch:
+        def from_dict(dct: dict[str, Any], nodes: MutableMapping[int, KCFG.Node]) -> KCFG.NDBranch:
             return KCFG.NDBranch(
                 nodes[dct['source']], tuple([nodes[target] for target in dct['targets']]), tuple(dct['rules'])
             )

--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -236,6 +236,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             return {
                 'source': self.source.id,
                 'targets': [target.id for target in self.targets],
+                'rules': list(self.rules),
             }
 
         def with_single_target(self, target: KCFG.Node) -> KCFG.NDBranch:

--- a/src/tests/unit/test_kcfg.py
+++ b/src/tests/unit/test_kcfg.py
@@ -112,6 +112,7 @@ def ndbranch_dicts(*edges: tuple[int, Iterable[tuple[int, bool]]]) -> list[dict[
         {
             'source': source_id,
             'targets': [target_id for target_id, _ in target_ids],
+            'rules': [],
         }
         for source_id, target_ids in edges
     ]


### PR DESCRIPTION
We want to move towards having a KCFG store (https://github.com/runtimeverification/pyk/issues/919). This PR is a step in that direction:

- All of the `KCFG` elements (`Node` and `Successor`) implement their own `from_dict` functionality. The `Successor` need to be passed in teh `_nodes` mapping in order to construct themselves properly.
- The `KCFG.read_cfg_data` is refactored to make use of existing `KCFG.from_dict`, instead of re-implementing.
- A new method `KCFG.add_successor` is added for directly adding new successors, instead of for each individual edge type. The various `KCFG.create_{Successor}` methods are refactored to use this.
- The `KCFG.from_dict` directly creates the needed `Succesor` directly, and then uses `KCFG.add_successor` instead of the individual creation methods which are used as helpers for passing in less data.

This is to prepare us for storing just a single `_successors: dict[int, KCFG.Successor]` mapping later, without having to make major changes to the code for loading/unloading KCFGs.