### PR TITLE
Fix NDBranch typing.

### DIFF
--- a/src/pyk/kcfg/kcfg.py
+++ b/src/pyk/kcfg/kcfg.py
@@ -325,7 +325,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
     _edges: dict[int, Edge]
     _covers: dict[int, Cover]
     _splits: dict[int, Split]
-    _ndbranches: dict[int, NDBranch]
+    _ndbranches: dict[int, KCFG.NDBranch]
     _vacuous: set[int]
     _stuck: set[int]
     _aliases: dict[str, int]
@@ -827,7 +827,9 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         self.add_successor(split)
         return split
 
-    def ndbranches(self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None) -> list[NDBranch]:
+    def ndbranches(
+        self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None
+    ) -> list[KCFG.NDBranch]:
         source_id = self._resolve(source_id) if source_id is not None else None
         target_id = self._resolve(target_id) if target_id is not None else None
         return [
@@ -836,7 +838,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             if (source_id is None or source_id == b.source.id) and (target_id is None or target_id in b.target_ids)
         ]
 
-    def contains_ndbranch(self, ndbranch: NDBranch) -> bool:
+    def contains_ndbranch(self, ndbranch: KCFG.NDBranch) -> bool:
         return ndbranch in self._ndbranches
 
     def create_ndbranch(


### PR DESCRIPTION
The kcfg module contains two classes named `NDBranch`. When using this module from Simbolik - mypy confused the types. This PR disambiguates some type annotations to aid mypy.